### PR TITLE
receiverScript now reads credentials from environment variables 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ Receive a Pushnotification when someone opens your Mailbox (Postbox)
 3. Upload MailAlertingClient.ino to ESP
 4. Setup RapberryPi
 5. _OPTIONAL: Install Mosquitto MQTT Broker on RasberryPi)_
-6. Copy receiverService.py to /home/pi directory
+6. Copy receiverService.py to /home/pi/ directory
 7. Install pip dependencies
-8. Copy MailboxReceiverService.service to /etc/systemd/system
+8. Copy MailboxReceiverService.service to /etc/systemd/system/
 9. Make script executable (chmod)
-10. Reload systemd & enable service
+10. Set neccesary enviroment variables 
+11. Reload systemd & enable service
 
 ## Code
 1. Clone the repo
@@ -36,9 +37,7 @@ Receive a Pushnotification when someone opens your Mailbox (Postbox)
 | wifiPassword     |               | Password of your Wifi                                                                                                |
 | MQTT_BROKER_IP   |               | IP of your MQTT Broker (If you run the MQTT Broker on the Raspberry Pi this will be the same IP as the Raspberry IP) |
 | MQTT_BROKER_PORT | 1883          | Port of the MQTT broker.                                                                                             |
-| MQTT_CLIENT_NAME | maclient      | Client name which the ESP will use to publish                                                                        |
-|                  |               |                                                                                                                      |
-**ReceiverService/receiverService.py**  
+| MQTT_CLIENT_NAME | maclient      | Client name which the ESP will use to publish                                                                        |                          
 
 | Variable                          | Default Value                                   | Description                                                                                                                                                                                                                                                                                                              |
 | --------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -48,10 +47,10 @@ Receive a Pushnotification when someone opens your Mailbox (Postbox)
 | DEVICES_FOR_IMPLICIT_NOTIFICATION | None                                            | V2Ids of Devices, which should receive a notification on a implicit Mailbox open. This is send when the receiver Service receives two closed states without an open state in between. You can target specific devices by setting this to a arry of ids e.g. `['AB12']`. The default setting will publish to all Devices. |
 | MAILBOX_OPEN_TEXT                 | Mailbox was opened                              | Text which should get pushed to the devices on Mailbox open.                                                                                                                                                                                                                                                             |
 | MAILBOX_STATE_MISSED_TEXT         | Mailbox was opened (explicit open state missed) | Text which should get pushed to the devices on implicit Mailbox open. This is send when the receiver Service receives two closed states without an open state in between.                                                                                                                                                |
-| PUSH_NOTIFIER_USER_NAME           |                                                 | UserName of your PushNotifier Account                                                                                                                                                                                                                                                                                    |
-| PUSH_NOTIFIER_PASSWORD            |                                                 | Password of your PushNotifier Account                                                                                                                                                                                                                                                                                    |
+| PUSH_NOTIFIER_USER_NAME           |                                                 | UserName of your PushNotifier Account (Please set this as environment variable!)                                                                                                                                                                                                                                                                                         |
+| PUSH_NOTIFIER_PASSWORD            |                                                 | Password of your PushNotifier Account (Please set this as environment variable!)                                                                                                                                                                                                                                                                                        |
 | PUSH_NOTIFIER_PACKAGE_NAME        |                                                 | Packagename of your PushNotifier App                                                                                                                                                                                                                                                                                     |
-| PUSH_NOTIFIER_API_KEY             |                                                 | APIKey of your PushNotifier Account                                                                                                                                                                                                                                                                                      |
+| PUSH_NOTIFIER_API_KEY             |                                                 | APIKey of your PushNotifier Account (Please set this as environment variable!)                                                                                                                                                                                                                                                                                      |
 
 ## ESP Setup
 ### Dependencies
@@ -77,7 +76,6 @@ Install Python dependencies
 > pip install paho-mqtt
 > pip install pushnotifier
 ```
-
 Setup systemd to automatically start the receiverService.py
 ```console
 > sudo chmod 744 MailboxReceiverService.service
@@ -87,3 +85,25 @@ Setup systemd to automatically start the receiverService.py
 > sudo systemctl start MailboxReceiverService.service
 ```
 > NOTE: To Debug the systemd setup you can use `sudo systemctl status MailboxReceiverService.service` for the general status and `journalctl -e -u MailboxReceiverService` for more detailed logs
+
+
+## Setting environment variables 
+This was introduced as a security practice to keep credentials out of script files.
+
+### Temporary Environment Variables
+
+You can set an environment variable temporarily for your current terminal session using the `export` command:
+
+```bash
+export PUSH_NOTIFIER_USERNAME="your_username"
+export PUSH_NOTIFIER_PASSWORD="your_password"
+export PUSH_NOTIFIER_APIKEY="your_api_key"
+```
+### Permanent Environment Variables for user
+To set environment variables for a user permanently, you can add the export commands to the user's profile file. For a typical user, you can add them to the ~/.bashrc or ~/.bash_profile file
+
+```bash
+echo 'export PUSH_NOTIFIER_USERNAME="your_username"' >> ~/.bashrc
+echo 'export PUSH_NOTIFIER_PASSWORD="your_password"' >> ~/.bashrc
+echo 'export PUSH_NOTIFIER_APIKEY="your_api_key"' >> ~/.bashrc
+```

--- a/ReceiverService/receiverService.py
+++ b/ReceiverService/receiverService.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import time
+import os
 import paho.mqtt.client as mqtt
 from pushnotifier import PushNotifier as pn
 
@@ -11,12 +12,13 @@ DEVICES_FOR_IMPLICIT_NOTIFICATION = None  # ['AB12']
 MAILBOX_OPEN_TEXT = "Mailbox was opened"
 MAILBOX_STATE_MISSED_TEXT = "Mailbox was opened (explicit open state missed)"
 
-PUSH_NOTIFIER_USER_NAME = "<PushNotifier UserName>"
-PUSH_NOTIFIER_PASSWORD = "<PushNotifier Password>"
+# Read environment variables for PushNotifier credentials
+PUSH_NOTIFIER_USER_NAME = os.environ["PUSH_NOTIFIER_USERNAME"]
+PUSH_NOTIFIER_PASSWORD = os.environ["PUSH_NOTIFIER_PASSWORD"]
+PUSH_NOTIFIER_API_KEY = os.environ["PUSH_NOTIFIER_APIKEY"]
 PUSH_NOTIFIER_PACKAGE_NAME = "<PushNotifier PackageName>"
-PUSH_NOTIFIER_API_KEY = "<PushNotifier APIKey>"
 
-print("Sleeping for 60 seconds to give the mqtt broker time to start")
+print("Sleeping for 60 seconds to give the MQTT broker time to start")
 time.sleep(60)
 print("Starting script")
 
@@ -29,11 +31,9 @@ LOW_STATE = b'LOW'
 last_status = HIGH_STATE
 is_first_message = True
 
-
 def on_connect(client, userdata, flags, rc):
     print(f"Connected with result code {rc}")
     client.subscribe("mailbox/#", 2)
-
 
 def on_message(client, userdata, msg):
     global last_status
@@ -41,17 +41,14 @@ def on_message(client, userdata, msg):
     print(msg.topic+" "+str(msg.payload))
 
     if last_status != msg.payload and msg.payload == LOW_STATE:
-        pn.send_text(MAILBOX_OPEN_TEXT, silent=False,
-                     devices=DEVICES_FOR_NOTIFICATION)
+        pn.send_text(MAILBOX_OPEN_TEXT, silent=False, devices=DEVICES_FOR_NOTIFICATION)
 
     # explicit open state was missed
     if last_status == msg.payload and not is_first_message:
-        pn.send_text(MAILBOX_STATE_MISSED_TEXT, silent=True,
-                     devices=DEVICES_FOR_IMPLICIT_NOTIFICATION)
+        pn.send_text(MAILBOX_STATE_MISSED_TEXT, silent=True, devices=DEVICES_FOR_IMPLICIT_NOTIFICATION)
 
     last_status = msg.payload
     is_first_message = False
-
 
 client = mqtt.Client()
 client.on_connect = on_connect

--- a/ReceiverService/receiverService.py
+++ b/ReceiverService/receiverService.py
@@ -12,11 +12,15 @@ DEVICES_FOR_IMPLICIT_NOTIFICATION = None  # ['AB12']
 MAILBOX_OPEN_TEXT = "Mailbox was opened"
 MAILBOX_STATE_MISSED_TEXT = "Mailbox was opened (explicit open state missed)"
 
-# Read environment variables for PushNotifier credentials
-PUSH_NOTIFIER_USER_NAME = os.environ["PUSH_NOTIFIER_USERNAME"]
-PUSH_NOTIFIER_PASSWORD = os.environ["PUSH_NOTIFIER_PASSWORD"]
-PUSH_NOTIFIER_API_KEY = os.environ["PUSH_NOTIFIER_APIKEY"]
-PUSH_NOTIFIER_PACKAGE_NAME = "<PushNotifier PackageName>"
+try:
+    PUSH_NOTIFIER_USER_NAME = os.environ["PUSH_NOTIFIER_USER_NAME"]
+    PUSH_NOTIFIER_PASSWORD = os.environ["PUSH_NOTIFIER_PASSWORD"]
+    PUSH_NOTIFIER_API_KEY = os.environ["PUSH_NOTIFIER_API_KEY"]
+    PUSH_NOTIFIER_PACKAGE_NAME = "<PushNotifier PackageName>"  # You can set this if needed
+
+except KeyError as e:
+    print(f"Error: {e} environment variable is not set.")
+    exit(1)
 
 print("Sleeping for 60 seconds to give the MQTT broker time to start")
 time.sleep(60)


### PR DESCRIPTION
This addresses the issue opened by @crnnr 

Credentials are now read from environment variables into the python script. Documentation for this practice was added to readme.

![grafik](https://github.com/MichaMican/mail-alerting/assets/87771733/b0f5084a-8854-4dae-91c5-eca2d62d531c)
